### PR TITLE
Fixes assignment of initialUrl in build store. Now initialUrl is assigned to urlFromQuery

### DIFF
--- a/core/server/index.js
+++ b/core/server/index.js
@@ -159,7 +159,7 @@ export default ({ clientStats }) => async (req, res) => {
           device,
           packages,
           isDev: !!req.query.dev,
-          initialUrl,
+          urlFromQuery: initialUrl,
           rendering: 'ssr',
           perPage: parseInt(perPage, 10),
           dynamicUrl,
@@ -174,6 +174,7 @@ export default ({ clientStats }) => async (req, res) => {
         ...envs,
       },
     );
+
     if (typeof window !== 'undefined') window.frontity = stores;
 
     // Notify that server is started.


### PR DESCRIPTION
fixes https://github.com/frontity/saturn-theme/issues/21