### PR TITLE
Get title from entity, even for the first pageview

### DIFF
--- a/core/client/index.js
+++ b/core/client/index.js
@@ -125,11 +125,17 @@ const init = async () => {
 
   // Create MST Stores
   const Stores = Store.props(storesProps);
+  const { type, id, page } = window['wp-pwa'];
 
   stores = Stores.create(window['wp-pwa'].initialState, {
     request,
     machine: 'server',
     ...envs,
+    initialSelectedItem: {
+      type,
+      id: parseInt(id, 10),
+      page: parseInt(page, 10),
+    },
   });
   if (dev) {
     const makeInspectable = require('mobx-devtools-mst').default;

--- a/core/client/index.js
+++ b/core/client/index.js
@@ -126,6 +126,7 @@ const init = async () => {
   // Create MST Stores
   const Stores = Store.props(storesProps);
   const { type, id, page } = window['wp-pwa'];
+  const parsedId = parseInt(id, 10);
 
   stores = Stores.create(window['wp-pwa'].initialState, {
     request,
@@ -133,7 +134,7 @@ const init = async () => {
     ...envs,
     initialSelectedItem: {
       type,
-      id: parseInt(id, 10),
+      id: Number.isNaN(parsedId) ? id : parsedId,
       page: parseInt(page, 10),
     },
   });

--- a/core/packages/analytics/amp/components/GoogleAnalytics.js
+++ b/core/packages/analytics/amp/components/GoogleAnalytics.js
@@ -38,7 +38,7 @@ const GoogleAnalytics = ({ id, pageView, vars, triggers }) => {
         <script
           type="application/json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify(json),
+            __html: JSON.stringify(json, null, 2),
           }}
         />
       </amp-analytics>

--- a/core/packages/analytics/amp/components/GoogleTagManager.js
+++ b/core/packages/analytics/amp/components/GoogleTagManager.js
@@ -19,7 +19,7 @@ const GoogleTagManager = ({ id, vars }) => (
       <script
         type="application/json"
         dangerouslySetInnerHTML={{
-          __html: JSON.stringify({ vars }),
+          __html: JSON.stringify({ vars }, null, 2),
         }}
       />
     </amp-analytics>

--- a/core/packages/analytics/amp/components/__tests__/__snapshots__/index.tests.js.snap
+++ b/core/packages/analytics/amp/components/__tests__/__snapshots__/index.tests.js.snap
@@ -8,7 +8,22 @@ Array [
     <script
       dangerouslySetInnerHTML={
         Object {
-          "__html": "{\\"vars\\":{\\"account\\":\\"UA-12345678-1\\"},\\"triggers\\":{\\"openMenu\\":{\\"on\\":\\"click\\",\\"selector\\":\\".menu\\",\\"request\\":\\"event\\",\\"vars\\":{\\"eventCategory\\":\\"AMP - Post bar\\",\\"eventAction\\":\\"AMP - open menu\\"}}}}",
+          "__html": "{
+  \\"vars\\": {
+    \\"account\\": \\"UA-12345678-1\\"
+  },
+  \\"triggers\\": {
+    \\"openMenu\\": {
+      \\"on\\": \\"click\\",
+      \\"selector\\": \\".menu\\",
+      \\"request\\": \\"event\\",
+      \\"vars\\": {
+        \\"eventCategory\\": \\"AMP - Post bar\\",
+        \\"eventAction\\": \\"AMP - open menu\\"
+      }
+    }
+  }
+}",
         }
       }
       type="application/json"
@@ -20,7 +35,22 @@ Array [
     <script
       dangerouslySetInnerHTML={
         Object {
-          "__html": "{\\"vars\\":{\\"account\\":\\"UA-12345678-2\\"},\\"triggers\\":{\\"openMenu\\":{\\"on\\":\\"click\\",\\"selector\\":\\".menu\\",\\"request\\":\\"event\\",\\"vars\\":{\\"eventCategory\\":\\"AMP - Post bar\\",\\"eventAction\\":\\"AMP - open menu\\"}}}}",
+          "__html": "{
+  \\"vars\\": {
+    \\"account\\": \\"UA-12345678-2\\"
+  },
+  \\"triggers\\": {
+    \\"openMenu\\": {
+      \\"on\\": \\"click\\",
+      \\"selector\\": \\".menu\\",
+      \\"request\\": \\"event\\",
+      \\"vars\\": {
+        \\"eventCategory\\": \\"AMP - Post bar\\",
+        \\"eventAction\\": \\"AMP - open menu\\"
+      }
+    }
+  }
+}",
         }
       }
       type="application/json"
@@ -33,7 +63,33 @@ Array [
     <script
       dangerouslySetInnerHTML={
         Object {
-          "__html": "{\\"vars\\":{\\"anonymize\\":false,\\"siteId\\":\\"site1122334455\\",\\"userIds\\":[\\"user00\\",\\"user01\\"],\\"theme\\":\\"saturn-theme\\",\\"extensions\\":\\"saturn-theme,wp-org-connection\\",\\"plan\\":\\"enterprise\\",\\"pageType\\":\\"pwa\\",\\"dev\\":true,\\"site\\":\\"https://demo.frontity.test\\",\\"title\\":\\"The Beauties of Gullfoss\\",\\"url\\":\\"https://demo.frontity.test/the-beauties-of-gullfoss/\\",\\"type\\":\\"post\\",\\"id\\":60,\\"format\\":\\"pwa\\",\\"route\\":\\"single\\",\\"hash\\":\\"ZO0H2I9kJ0arOdstZdG\\",\\"customDimensions\\":{\\"dimension1\\":\\"dim1_post60\\",\\"dimension2\\":\\"dim2_post60\\"}}}",
+          "__html": "{
+  \\"vars\\": {
+    \\"anonymize\\": false,
+    \\"siteId\\": \\"site1122334455\\",
+    \\"userIds\\": [
+      \\"user00\\",
+      \\"user01\\"
+    ],
+    \\"theme\\": \\"saturn-theme\\",
+    \\"extensions\\": \\"saturn-theme,wp-org-connection\\",
+    \\"plan\\": \\"enterprise\\",
+    \\"pageType\\": \\"pwa\\",
+    \\"dev\\": true,
+    \\"site\\": \\"https://demo.frontity.test\\",
+    \\"title\\": \\"The Beauties of Gullfoss\\",
+    \\"url\\": \\"https://demo.frontity.test/the-beauties-of-gullfoss/\\",
+    \\"type\\": \\"post\\",
+    \\"id\\": 60,
+    \\"format\\": \\"pwa\\",
+    \\"route\\": \\"single\\",
+    \\"hash\\": \\"ZO0H2I9kJ0arOdstZdG\\",
+    \\"customDimensions\\": {
+      \\"dimension1\\": \\"dim1_post60\\",
+      \\"dimension2\\": \\"dim2_post60\\"
+    }
+  }
+}",
         }
       }
       type="application/json"

--- a/core/packages/analytics/amp/components/__tests__/index.tests.js
+++ b/core/packages/analytics/amp/components/__tests__/index.tests.js
@@ -6,14 +6,14 @@ import Analytics from '..';
 
 const Stores = types.model('Stores').props({
   connection: types.optional(types.frozen, {
-    head: { title: 'The Beauties of Gullfoss – Demo Frontity' },
+    selectedItem: { type: 'post', id: 60 },
   }),
   analytics: types.optional(types.frozen, {
     googleAnalytics: {
       ids: ['UA-12345678-1', 'UA-12345678-2'],
       trackingOptions: () => ({ sendPageViews: false, sendEvents: true }),
       pageView: {
-        title: 'The Beauties of Gullfoss',
+        title: 'The Beauties of Gullfoss – Demo Frontity',
         url: 'https://demo.frontity.test/the-beauties-of-gullfoss/',
         cd1: 'dim1_post60',
         cd2: 'dim2_post60',

--- a/core/packages/analytics/pwa/components/__tests__/__snapshots__/index.tests.js.snap
+++ b/core/packages/analytics/pwa/components/__tests__/__snapshots__/index.tests.js.snap
@@ -13,11 +13,36 @@ window.dataLayer.push({
 });
 window.dataLayer.push({
   event: 'wpPwaProperties',
-  wpPwaProperties: {\\"anonymize\\":false,\\"siteId\\":\\"site1122334455\\",\\"userIds\\":[\\"user00\\",\\"user01\\"],\\"theme\\":\\"saturn-theme\\",\\"extensions\\":\\"saturn-theme,wp-org-connection\\",\\"plan\\":\\"enterprise\\",\\"pageType\\":\\"pwa\\",\\"dev\\":true},
+  wpPwaProperties: {
+  \\"anonymize\\": false,
+  \\"siteId\\": \\"site1122334455\\",
+  \\"userIds\\": [
+    \\"user00\\",
+    \\"user01\\"
+  ],
+  \\"theme\\": \\"saturn-theme\\",
+  \\"extensions\\": \\"saturn-theme,wp-org-connection\\",
+  \\"plan\\": \\"enterprise\\",
+  \\"pageType\\": \\"pwa\\",
+  \\"dev\\": true
+},
 });
 window.dataLayer.push({
   event: 'virtualPageview',
-  virtualPageview: {\\"title\\":\\"The Beauties of Gullfoss – Demo Frontity\\",\\"site\\":\\"https://demo.frontity.test\\",\\"url\\":\\"https://demo.frontity.test/the-beauties-of-gullfoss/\\",\\"type\\":\\"post\\",\\"id\\":60,\\"format\\":\\"pwa\\",\\"route\\":\\"single\\",\\"hash\\":\\"ZO0H2I9kJ0arOdstZdG\\",\\"customDimensions\\":{\\"dimension1\\":\\"dim1_post60\\",\\"dimension2\\":\\"dim2_post60\\"}},
+  virtualPageview: {
+  \\"site\\": \\"https://demo.frontity.test\\",
+  \\"title\\": \\"The Beauties of Gullfoss – Demo Frontity\\",
+  \\"url\\": \\"https://demo.frontity.test/the-beauties-of-gullfoss/\\",
+  \\"type\\": \\"post\\",
+  \\"id\\": 60,
+  \\"format\\": \\"pwa\\",
+  \\"route\\": \\"single\\",
+  \\"hash\\": \\"ZO0H2I9kJ0arOdstZdG\\",
+  \\"customDimensions\\": {
+    \\"dimension1\\": \\"dim1_post60\\",
+    \\"dimension2\\": \\"dim2_post60\\"
+  }
+},
 });",
       }
     }

--- a/core/packages/analytics/pwa/components/__tests__/index.tests.js
+++ b/core/packages/analytics/pwa/components/__tests__/index.tests.js
@@ -6,7 +6,7 @@ import Analytics from '..';
 
 const Stores = types.model('Stores').props({
   connection: types.optional(types.frozen, {
-    head: { title: 'The Beauties of Gullfoss – Demo Frontity' },
+    selectedItem: { type: 'post', id: 60 },
   }),
   analytics: types.optional(types.frozen, {
     customDimensions: () => ({
@@ -30,7 +30,7 @@ const Stores = types.model('Stores').props({
       },
       pageViewProperties: {
         site: 'https://demo.frontity.test',
-        title: 'The Beauties of Gullfoss',
+        title: 'The Beauties of Gullfoss – Demo Frontity',
         url: 'https://demo.frontity.test/the-beauties-of-gullfoss/',
         type: 'post',
         id: 60,

--- a/core/packages/analytics/pwa/components/index.js
+++ b/core/packages/analytics/pwa/components/index.js
@@ -1,9 +1,7 @@
 /* eslint-disable react/no-danger */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-// import { inject } from 'mobx-react';
 import { compose, getContext, mapProps } from 'recompose';
-import { decode } from 'he';
 import GoogleTagManager from './GoogleTagManager';
 import GoogleAnalytics from './GoogleAnalytics';
 import ComScore from './ComScore';
@@ -15,14 +13,11 @@ const Analytics = ({
   gaIds,
   gaCustomDimensions,
   comScoreIds,
-  title,
-}) => {
-  const { title: _, ...gtmPageView } = gtmPageViewProperties;
-  return (
-    <Fragment>
-      <script
-        dangerouslySetInnerHTML={{
-          __html: `
+}) => (
+  <Fragment>
+    <script
+      dangerouslySetInnerHTML={{
+        __html: `
 window.dataLayer = window.dataLayer || [];
 window.dataLayer.push({
   'gtm.start': Date.now(),
@@ -30,27 +25,22 @@ window.dataLayer.push({
 });
 window.dataLayer.push({
   event: 'wpPwaProperties',
-  wpPwaProperties: ${JSON.stringify(gtmClientProperties)},
+  wpPwaProperties: ${JSON.stringify(gtmClientProperties, null, 2)},
 });
 window.dataLayer.push({
   event: 'virtualPageview',
-  virtualPageview: ${JSON.stringify({ title, ...gtmPageView })},
+  virtualPageview: ${JSON.stringify(gtmPageViewProperties, null, 2)},
 });`,
-        }}
-      />
-      {/* <GoogleTagManager key="GTM-K3S2BMT" id="GTM-K3S2BMT" /> */}
-      {gtmIds.map(id => <GoogleTagManager key={id} id={id} />)}
-      {gaIds.map(id => (
-        <GoogleAnalytics
-          key={id}
-          id={id}
-          customDimensions={gaCustomDimensions}
-        />
-      ))}
-      {comScoreIds.map(id => <ComScore key={id} id={id} />)}
-    </Fragment>
-  );
-};
+      }}
+    />
+    {/* <GoogleTagManager key="GTM-K3S2BMT" id="GTM-K3S2BMT" /> */}
+    {gtmIds.map(id => <GoogleTagManager key={id} id={id} />)}
+    {gaIds.map(id => (
+      <GoogleAnalytics key={id} id={id} customDimensions={gaCustomDimensions} />
+    ))}
+    {comScoreIds.map(id => <ComScore key={id} id={id} />)}
+  </Fragment>
+);
 
 Analytics.propTypes = {
   gtmIds: PropTypes.arrayOf(PropTypes.string),
@@ -61,7 +51,6 @@ Analytics.propTypes = {
   comScoreIds: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ),
-  title: PropTypes.string.isRequired,
 };
 
 Analytics.defaultProps = {
@@ -86,5 +75,4 @@ export default injectNotObserver(({ stores: { analytics, connection } }) => ({
   gaIds: analytics.googleAnalytics.ids,
   gaCustomDimensions: analytics.customDimensions(connection.selectedItem),
   comScoreIds: analytics.comScore.ids,
-  title: decode(connection.head.title).replace(/<\/?[^>]+(>|$)/g, ''),
 }))(Analytics);


### PR DESCRIPTION
Changes in Analytics package to get the page title directly from the entity, using `entity.headMeta.title` or `entity.headMeta.pagedTitle`.

Also, `initialSelectedItem` is passed in env when the mobx store is created in the client.

Fixes https://github.com/frontity/wp-org-connection/issues/20